### PR TITLE
Use std::map instead of std::unordered_map for loggers_ map. Disable default logger

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -14,7 +14,11 @@
 #include <functional>
 #include <memory>
 #include <string>
+#ifdef __freertos__
+#include <map>
+#else
 #include <unordered_map>
+#endif
 #include <mutex>
 
 namespace spdlog {
@@ -89,7 +93,11 @@ private:
     void register_logger_(std::shared_ptr<logger> new_logger);
     std::mutex logger_map_mutex_, flusher_mutex_;
     std::recursive_mutex tp_mutex_;
+#ifdef __freertos__
+    std::map<std::string, std::shared_ptr<logger>> loggers_;
+#else
     std::unordered_map<std::string, std::shared_ptr<logger>> loggers_;
+#endif
     std::unique_ptr<formatter> formatter_;
     level::level_enum level_ = level::info;
     level::level_enum flush_level_ = level::off;

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -103,7 +103,9 @@
 // Uncomment to disable default logger creation.
 // This might save some (very) small initialization time if no default logger is needed.
 //
-// #define SPDLOG_DISABLE_DEFAULT_LOGGER
+#ifdef __freertos__ 
+#define SPDLOG_DISABLE_DEFAULT_LOGGER
+#endif
 ///////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
These are the changes to make it work for `KPSR_WITH_FREERTOS`, with an `std::map` instead of an `std::unordered_map`. It also disables the default logger, since class `ansicolor_sink` also uses an `std::unordered_map`.

I had to create `branch_v1.5.0` from that version tag; otherwise I only would be able to create to PR to merge to the main branch, but `kpe-core` submodule points to the commit at `v1.5.0`.